### PR TITLE
Improve cat and input error handling

### DIFF
--- a/_oasis
+++ b/_oasis
@@ -7,7 +7,7 @@ Description: MPP is a meta processor that is meant to bring any programming lang
 Authors:     Philippe Wang <philippe.wang@gmail.com>
 Maintainers: Philippe Wang <philippe.wang@gmail.com>
 License:     ISC
-Homepage:    https://github.com/pw374/MPP-language-blender
+Homepage:    https://github.com/ocaml/MPP-language-blender
 Plugins:     META (0.3), StdFiles (0.3)
 
 Library "mpp"
@@ -24,6 +24,6 @@ Executable "mpp"
 
 SourceRepository master
   Type:       git
-  Location:   https://github.com/pw374/MPP-language-blender.git
-  Browser:    https://github.com/pw374/MPP-language-blender
+  Location:   https://github.com/ocaml/MPP-language-blender.git
+  Browser:    https://github.com/ocaml/MPP-language-blender
 

--- a/src/mpp_main.ml
+++ b/src/mpp_main.ml
@@ -223,7 +223,7 @@ let init() =
        preprocess function.  *)
     let builtin__input =
       (fun __last_cond _nesting arg cs out ->
-        let arg = string_of_charstream arg in
+        let arg = String.trim (string_of_charstream arg) in
         try
           let x = open_in arg in
             cs.insert (charstream_of_inchannel arg x);

--- a/src/mpp_main.ml
+++ b/src/mpp_main.ml
@@ -224,10 +224,12 @@ let init() =
     let builtin__input =
       (fun __last_cond _nesting arg cs out ->
         let arg = string_of_charstream arg in
-        let x = open_in arg in
-          cs.insert (charstream_of_inchannel arg x);
-          preprocess cs out;
-          close_in x
+        try
+          let x = open_in arg in
+            cs.insert (charstream_of_inchannel arg x);
+            preprocess cs out;
+            close_in x
+        with Sys_error s -> Printf.eprintf "\"input %s\" failed: %s\n" arg s
       )
     in
       Mpp_actions.register "input" builtin__input "Input and process a file.";

--- a/src/mpp_out.ml
+++ b/src/mpp_out.ml
@@ -54,6 +54,7 @@ let output_charstream o cs =
     | Out_channel o -> Pervasives.output_string o (Mpp_charstream.string_of_charstream ~keepcs:true cs)
 
 let cat (out:t) filename =
+  let filename = String.trim filename in
   try
     let i = open_in filename in
       try while true do

--- a/src/mpp_out.ml
+++ b/src/mpp_out.ml
@@ -53,14 +53,11 @@ let output_charstream o cs =
     | Buffer buff -> Buffer.add_string buff (Mpp_charstream.string_of_charstream ~keepcs:true cs)
     | Out_channel o -> Pervasives.output_string o (Mpp_charstream.string_of_charstream ~keepcs:true cs)
 
-
 let cat (out:t) filename =
-  if Sys.file_exists filename then
+  try
     let i = open_in filename in
       try while true do
         output_char out (input_char i)
       done with End_of_file -> ()
-  else
-    Printf.eprintf
-      "builtin cat error: file <%s> doesn't exist.\n%!"
-      filename
+  with Sys_error s ->
+    Printf.eprintf "\"cat %s\" failed: %s\n" filename s


### PR DESCRIPTION
I made cat and input catch Sys_error that may arise from open_in and print an error message.
Before that cat only checked if file exists, and input didn't do any checks at all, so the Sys_error would be shown to the user.
The behaviour is modelled after old cat behaviour (print an error and proceed), but it should be easy to add an option to stop on errors.

I also made cat and input ignore leading/trailing whitespace. Accidental whitespace is common (I hit it with "{{! input ((! get filename !)) !}}"), it's probably better to be more forgiving about it.

Also, updated homepage and repo links.