### PR TITLE
add missing ocamlbuild dependency

### DIFF
--- a/opam
+++ b/opam
@@ -17,6 +17,7 @@ remove: [
 ]
 depends: [
   "ocamlfind"
+  "ocamlbuild" {build}
 ]
 tags: [
   "org:ocamllabs"


### PR DESCRIPTION
see https://github.com/ocaml/opam-repository/pull/8559

opam-builder report:
  http://opam.ocamlpro.com/builder/html/mpp/mpp.0.3.0/ad16906675fc9f5dbee3f2203f64b634